### PR TITLE
Leak fix

### DIFF
--- a/monty.c
+++ b/monty.c
@@ -1,7 +1,7 @@
 #include "monty.h"
 
 void free_stack(stack_t *stack);
-char mode = STAK_MODE;
+int misc[] = {0, 0, 0};
 
 /**
  * main - Process Monty byte codes from a file passed in as an argument.
@@ -20,6 +20,7 @@ int main(int argc, char **argv)
 	unsigned int line_number = 0;
 	stack_t *stack = NULL;
 
+	misc[MODE_IDX] = STAK_MODE;
 	if (argc != 2)
 	{
 		fprintf(stderr, "USAGE: monty file\n");
@@ -42,6 +43,12 @@ int main(int argc, char **argv)
 		proc_line(buffer, line_number, &stack);
 		free(buffer);
 		buffer = NULL;
+		if (misc[ERROR_IDX] != 0)
+		{
+			free_stack(stack);
+			fclose(monty_file);
+			exit(EXIT_FAILURE);
+		}
 		len = getline(&buffer, &n, monty_file);
 	}
 	free(buffer);

--- a/monty.h
+++ b/monty.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+
 /**
  * struct stack_s - doubly linked list representation of a stack (or queue)
  * @n: integer
@@ -34,7 +35,11 @@ typedef struct instruction_s
 	void (*f)(stack_t **stack, unsigned int line_number);
 } instruction_t;
 
-extern char mode;
+extern int misc[];
+
+#define N_IDX 0
+#define MODE_IDX 1
+#define ERROR_IDX 2
 
 #define STAK_MODE 1
 #define QUEU_MODE 0
@@ -43,7 +48,6 @@ void (*get_op(char *tok))(stack_t **stack, unsigned int line_number);
 void proc_line(char *buffer, unsigned int line_number, stack_t **stack);
 
 void push(stack_t **stack, unsigned int line_number);
-void real_push(stack_t **stack, char *n);
 void pall(stack_t **stack, unsigned int line_number);
 void pint(stack_t **stack, unsigned int line_number);
 void pop(stack_t **stack, unsigned int line_number);

--- a/shoyu.c
+++ b/shoyu.c
@@ -56,7 +56,7 @@ void proc_line(char *buffer, unsigned int line_number, stack_t **stack)
 	char *save_point;
 	void (*f)(stack_t **stack, unsigned int line_number);
 
-	token = strtok_r(buffer, " ", &save_point);
+	token = strtok_r(buffer, " \t\n", &save_point);
 	if (token != NULL && token[0] != '#')
 	{
 		f = get_op(token);
@@ -64,19 +64,21 @@ void proc_line(char *buffer, unsigned int line_number, stack_t **stack)
 		{
 			fprintf(stderr, "L%u: unknown instruction %s\n",
 					line_number, token);
-			exit(EXIT_FAILURE);
+			misc[ERROR_IDX] = 1;
+			return;
 		}
 		if (f == push)
 		{
 			token = strtok_r(NULL, " ", &save_point);
 			if (token == NULL || check_num(token) == 0)
-				push(stack, line_number);
-			real_push(stack, token);
+			{
+				fprintf(stderr, "L%u: usage: push integer\n",
+						line_number);
+				misc[ERROR_IDX] = 1;
+				return;
+			}
+			misc[N_IDX] = atoi(token);
 		}
-		else
-		{
-			f(stack, line_number);
-		}
+		f(stack, line_number);
 	}
 }
-

--- a/stak_funcs_1.c
+++ b/stak_funcs_1.c
@@ -1,41 +1,32 @@
 #include "monty.h"
 
 /**
- * push - fake push
+ * push - Pushes a node to a datastructure. FIFO for queue mode, LIFO for stack
+ * mode.
+ *
  * @stack: a pointer to a pointer to the stack
- * @line_number: holds the line the code is run
+ * @line_number: Pointer to string containing a number.
  */
 
 void push(stack_t **stack, unsigned int line_number)
 {
-	(void) stack;
-	fprintf(stderr, "L%u: usage: push integer\n", line_number);
-	exit(EXIT_FAILURE);
-}
-
-/**
- * real_push - The real push: pushes a node to a stack
- * @stack: a pointer to a pointer to the stack
- * @n: Pointer to string containing a number.
- */
-
-void real_push(stack_t **stack, char *n)
-{
 	stack_t *new;
 	stack_t *end;
+	(void) line_number;
 
 	new = malloc(sizeof(stack_t));
 
 	if (new == NULL)
 	{
 		fprintf(stderr, "Error: malloc failed\n");
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 
-	new->n = atoi(n);
+	new->n = misc[N_IDX];
 	new->prev = NULL;
 	new->next = NULL;
-	if (mode == STAK_MODE)
+	if (misc[MODE_IDX] == STAK_MODE)
 	{
 		new->next = (*stack);
 		if (*stack)
@@ -89,7 +80,8 @@ void pint(stack_t **stack, unsigned int line_number)
 	if (stack == NULL || *stack == NULL)
 	{
 		fprintf(stderr, "L%u: can't pint, stack empty\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 	printf("%d\n", (*stack)->n);
 }
@@ -107,7 +99,8 @@ void pop(stack_t **stack, unsigned int line_number)
 	if (stack == NULL || *stack == NULL)
 	{
 		fprintf(stderr, "L%u: can't pop an empty stack\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 
 	head = *stack;

--- a/stak_funcs_2.c
+++ b/stak_funcs_2.c
@@ -14,7 +14,8 @@ void swap(stack_t **stack, unsigned int line_number)
 	if (stack == NULL || *stack == NULL || (*stack)->next == NULL)
 	{
 		fprintf(stderr, "L%u: can't swap, stack too short\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 
 	head = *stack;
@@ -36,7 +37,8 @@ void add(stack_t **stack, unsigned int line_number)
 	if (stack == NULL || *stack == NULL || (*stack)->next == NULL)
 	{
 		fprintf(stderr, "L%u: can't add, stack too short\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 	res = (*stack)->n + (*stack)->next->n;
 	pop(stack, line_number);
@@ -56,7 +58,8 @@ void sub(stack_t **stack, unsigned int line_number)
 	if (stack == NULL || *stack == NULL || (*stack)->next == NULL)
 	{
 		fprintf(stderr, "L%u: can't sub, stack too short\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 	res = (*stack)->next->n - (*stack)->n;
 	pop(stack, line_number);
@@ -80,12 +83,14 @@ void _div(stack_t **stack, unsigned int line_number)
 	if (stack == NULL || *stack == NULL || (*stack)->next == NULL)
 	{
 		fprintf(stderr, "L%u: can't div, stack too short\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 	if ((*stack)->n == 0)
 	{
 		fprintf(stderr, "L%u: division by zero\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 
 	res = (*stack)->next->n / (*stack)->n;

--- a/stak_funcs_3.c
+++ b/stak_funcs_3.c
@@ -17,7 +17,8 @@ void mul(stack_t **stack, unsigned int line_number)
 	if (stack == NULL || *stack == NULL || (*stack)->next == NULL)
 	{
 		fprintf(stderr, "L%u: can't mul, stack too short\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 	res = (*stack)->n * (*stack)->next->n;
 	pop(stack, line_number);
@@ -42,12 +43,14 @@ void mod(stack_t **stack, unsigned int line_number)
 	if (stack == NULL || *stack == NULL || (*stack)->next == NULL)
 	{
 		fprintf(stderr, "L%u: can't mod, stack too short\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 	if ((*stack)->n == 0)
 	{
 		fprintf(stderr, "L%u: division by zero\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 
 	res = (*stack)->next->n % (*stack)->n;
@@ -70,12 +73,14 @@ void pchar(stack_t **stack, unsigned int line_number)
 	if (stack == NULL || *stack == NULL)
 	{
 		fprintf(stderr, "L%u: can't pchar, stack empty\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
-	if ((*stack)->n < 0 || (*stack)->n > 127)
+	if (isascii((*stack)->n != 0))
 	{
 		fprintf(stderr, "L%u: can't pchar, value out of range\n", line_number);
-		exit(EXIT_FAILURE);
+		misc[ERROR_IDX] = 1;
+		return;
 	}
 
 	printf("%c\n", (*stack)->n);
@@ -101,7 +106,7 @@ void pstr(stack_t **stack, unsigned int line_number)
 		while (current != NULL)
 		{
 			ascii = current->n;
-			if (ascii != 0 && ascii >= 0 && ascii <= 127)
+			if (ascii != 0 && isascii(ascii) != 0)
 				putchar(ascii);
 			else
 				break;

--- a/stak_funcs_4.c
+++ b/stak_funcs_4.c
@@ -71,7 +71,7 @@ void stack_set(stack_t **stack, unsigned int line_number)
 	(void) stack;
 	(void) line_number;
 
-	mode = STAK_MODE;
+	misc[MODE_IDX] = STAK_MODE;
 }
 
 /**
@@ -88,5 +88,5 @@ void queue_set(stack_t **stack, unsigned int line_number)
 	(void) stack;
 	(void) line_number;
 
-	mode = QUEU_MODE;
+	misc[MODE_IDX] = QUEU_MODE;
 }


### PR DESCRIPTION
- Free memory before exit
- Include \t and \n as delimiters